### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.konsole.json
+++ b/org.kde.konsole.json
@@ -13,6 +13,10 @@
         "--socket=fallback-x11",
         "--talk-name=org.freedesktop.Flatpak"
     ],
+    "cleanup": [
+        "/share/doc",
+        "/share/qlogging-categories6"
+    ],
     "modules": [
         {
             "name": "konsole",


### PR DESCRIPTION
The installed size reduced from 5.7 MB to 4.1 MB.

KDE apps usually open an external website for help documentation.

Therefore, it's not required to keep the /share/doc folder.